### PR TITLE
feat: create reusable input components for chat input

### DIFF
--- a/src/components/Example/index.tsx
+++ b/src/components/Example/index.tsx
@@ -1,6 +1,10 @@
 import { useState } from "react";
 import viteLogo from "../../../public/vite.svg";
 import reactLogo from "../../assets/react.svg";
+import { FiMail } from "react-icons/fi";
+import FormInput from "../Ui/FormInput";
+import ChatInputBox from "../Ui/ChatInputBox";
+
 const ExampleComponent = () => {
   const [count, setCount] = useState<number>(0);
   return (
@@ -46,6 +50,8 @@ const ExampleComponent = () => {
       <p className="text-gradient-dayblue-blue-green-600">
         Click on the Vite and React logos to learn more
       </p>
+      <FormInput placeholder="Email" icon={<FiMail />} />
+      <ChatInputBox />
     </>
   );
 };

--- a/src/components/Ui/ChatInputBox.tsx
+++ b/src/components/Ui/ChatInputBox.tsx
@@ -1,0 +1,31 @@
+import { FiMic, FiPaperclip, FiSend } from "react-icons/fi";
+
+function ChatInput() {
+  return (
+    <div className="w-full px-4 py-3 rounded-xl bg-[rgba(6,7,8,1)] flex items-center gap-3 font-plus">
+      {/* Microphone Icon */}
+      <button className="cursor-pointer text-[rgba(155, 156, 158, 1)]">
+        <FiMic className="w-5 h-5" />
+      </button>
+
+      {/* Input Field */}
+      <input
+        type="text"
+        placeholder="You can ask me anything! I am here to help."
+        className="flex-1 bg-transparent text-white placeholder-[rgba(155, 156, 158, 1)] focus:outline-none"
+      />
+
+      {/* Attachment Icon */}
+      <button className="text-[rgba(155, 156, 158, 1)] cursor-pointer">
+        <FiPaperclip className="w-5 h-5" />
+      </button>
+
+      {/* Send Button */}
+      <button className="bg-[rgba(19,22,25,1)] rounded-full w-8 h-8 flex items-center justify-center cursor-pointer">
+        <FiSend className="w-4 h-4 text-white" />
+      </button>
+    </div>
+  );
+}
+
+export default ChatInput;

--- a/src/components/Ui/FormInput.tsx
+++ b/src/components/Ui/FormInput.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+
+interface InputProps {
+  type?: string;
+  placeholder: string;
+  value?: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  icon?: React.ReactNode;
+}
+
+const FormInput: React.FC<InputProps> = ({
+  type = "text",
+  placeholder,
+  value,
+  onChange,
+  icon,
+}) => {
+  return (
+    <div className="w-auto">
+      <div className="flex items-center gap-2 px-4 py-3 rounded-lg bg-[rgba(26,29,33,1)] border border-[rgba(54,58,61,1)] focus-within:border-day-blue-500 transition-colors">
+        {icon && <span className="text-noble-black-300">{icon}</span>}
+        <input
+          type={type}
+          placeholder={placeholder}
+          value={value}
+          onChange={onChange}
+          className="w-full bg-transparent outline-none text-[rgba(232,233,233,1)] placeholder:text-noble-black-400 text-sm"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default FormInput;


### PR DESCRIPTION
This commit introduces reusable input components used in the chat interface, including a styled input field and action buttons such as microphone, attachment, and send. The components are styled based on the design system colors and typography, promoting consistency and reusability across the project.
