### PR TITLE
feat(input): add focus styling with gradient border

### DIFF
--- a/src/components/Example/index.tsx
+++ b/src/components/Example/index.tsx
@@ -3,7 +3,7 @@ import viteLogo from "../../../public/vite.svg";
 import reactLogo from "../../assets/react.svg";
 import { FiMail } from "react-icons/fi";
 import FormInput from "../Ui/FormInput";
-import ChatInputBox from "../Ui/ChatInputBox";
+// import ChatInputBox from "../Ui/ChatInputBox";
 
 const ExampleComponent = () => {
   const [count, setCount] = useState<number>(0);
@@ -47,11 +47,16 @@ const ExampleComponent = () => {
       <p className="text-gradient-dayblue-blue-green-600">
         Click on the Vite and React logos to learn more
       </p>
-      <p className="text-gradient-dayblue-blue-green-600">
+      <p className="text-gradient-dayblue-blue-green-600 mb-7">
         Click on the Vite and React logos to learn more
       </p>
-      <FormInput placeholder="Email" icon={<FiMail />} />
-      <ChatInputBox />
+      <FormInput
+        placeholder="Email"
+        icon={<FiMail />}
+        placeholderPosition="left"
+      />
+
+      {/* <ChatInputBox /> */}
     </>
   );
 };

--- a/src/components/Ui/ChatInputBox.tsx
+++ b/src/components/Ui/ChatInputBox.tsx
@@ -2,7 +2,7 @@ import { FiMic, FiPaperclip, FiSend } from "react-icons/fi";
 
 function ChatInput() {
   return (
-    <div className="w-full px-4 py-3 rounded-xl bg-[rgba(6,7,8,1)] flex items-center gap-3 font-plus">
+    <div className="w-full px-4 py-3 pt-5 rounded-xl bg-[rgba(6,7,8,1)] flex items-center gap-3 font-plus">
       {/* Microphone Icon */}
       <button className="cursor-pointer text-[rgba(155, 156, 158, 1)]">
         <FiMic className="w-5 h-5" />

--- a/src/components/Ui/FormInput.tsx
+++ b/src/components/Ui/FormInput.tsx
@@ -6,6 +6,7 @@ interface InputProps {
   value?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   icon?: React.ReactNode;
+  placeholderPosition?: "left" | "center" | "right";
 }
 
 const FormInput: React.FC<InputProps> = ({
@@ -14,18 +15,35 @@ const FormInput: React.FC<InputProps> = ({
   value,
   onChange,
   icon,
+  placeholderPosition = "left",
 }) => {
+  const placeholderAlignClass = {
+    left: "text-left placeholder:text-left",
+    center: "text-center placeholder:text-center",
+    right: "text-right placeholder:text-right",
+  }[placeholderPosition];
+
   return (
     <div className="w-auto">
-      <div className="flex items-center gap-2 px-4 py-3 rounded-lg bg-[rgba(26,29,33,1)] border border-[rgba(54,58,61,1)] focus-within:border-day-blue-500 transition-colors">
-        {icon && <span className="text-noble-black-300">{icon}</span>}
-        <input
-          type={type}
-          placeholder={placeholder}
-          value={value}
-          onChange={onChange}
-          className="w-full bg-transparent outline-none text-[rgba(232,233,233,1)] placeholder:text-noble-black-400 text-sm"
-        />
+      <div
+        className={`
+          relative p-[2px] rounded-lg
+          transition-colors duration-300
+          bg-transparent
+          focus-within:bg-gradient-blue-green-500
+          focus-within:shadow-[0_0_0_3px_#82dbf7,0_0_10px_#b6f09c]
+        `}
+      >
+        <div className="flex items-center gap-2 px-4 py-3 rounded-lg bg-[rgba(26,29,33,1)] border border-transparent">
+          {icon && <span className="text-noble-black-300">{icon}</span>}
+          <input
+            type={type}
+            placeholder={placeholder}
+            value={value}
+            onChange={onChange}
+            className={`w-full bg-transparent outline-none text-[rgba(232,233,233,1)] placeholder:text-noble-black-400 text-sm ${placeholderAlignClass}`}
+          />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
- Implemented dynamic placeholder alignment (left, center, right) via `placeholderPosition` prop.
- Applied gradient focus styling using `bg-gradient-blue-green-500` and matching box-shadow (#82dbf7, #b6f09c).
- Added padding-top to the input container to match the chat input spacing in Figma design.

Closes #12
